### PR TITLE
Add sdk qualifier for dart 2 (seems to be mandatory for flutter now).

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,3 +5,6 @@ description: Semaphore is lightweight data type that is used for controlling acc
 homepage: https://github.com/mezoni/semaphore
 dev_dependencies:
   test: any
+
+environment:
+  sdk: '>=1.22.0 <3.0.0'


### PR DESCRIPTION
I could not consume the semaphore dependency using flutter without this sdk declaration.