### PR TITLE
Add signal

### DIFF
--- a/lib/signal.dart
+++ b/lib/signal.dart
@@ -1,0 +1,1 @@
+export 'src/semaphore/signal.dart';

--- a/lib/src/semaphore/signal.dart
+++ b/lib/src/semaphore/signal.dart
@@ -1,0 +1,19 @@
+import 'dart:async';
+import 'dart:collection';
+
+class Signal {
+  final _waitQueue = Queue<Completer<void>>();
+
+  Future<void> waitForSignal() {
+    final completer = Completer<void>();
+    _waitQueue.add(completer);
+    return completer.future;
+  }
+
+  void signal() {
+    for (final completer in _waitQueue) {
+      completer.complete();
+    }
+    _waitQueue.clear();
+  }
+}


### PR DESCRIPTION
It would be cool if this package could also provide signals. (One client does `await signal.waitForSignal()` and when another one calls `signal.signal()`, the first client's Future completes.)